### PR TITLE
22 incoherent python and scipy version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Sci. Adv., 8 (19), eabj3063. DOI: 10.1126/sciadv.abj3063
 
 <!--- quickstart --->
 ## Requirements:
-- Python3 (>=3.6)
+- Python3 (>=3.9)
 - pandas
 - scipy
 - numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
     {name="Alexandre Bovet", email="alexandre.bovet@uzh.ch"},
 ]
 description = "Framework for dynamic community detection in temporal networks."
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: GNU LGPL",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cython>=3.0.8
-pandas>=2.2.1
-scipy>=1.12.0
-hickle==5.0.2
+Cython>=3.0.11
+pandas>=2.2.2
+scipy>=1.13.1
+hickle>=5.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Cython>=3.0.11
 pandas>=2.2.2
 scipy>=1.13.1
 hickle>=5.0.3
+psutil>=6.0.0

--- a/src/flowstab/scripts/run_cov_integrals.py
+++ b/src/flowstab/scripts/run_cov_integrals.py
@@ -45,6 +45,7 @@ import time
 import traceback
 import re
 import gc
+import psutil
 import numpy as np
 import pandas as pd
 
@@ -141,7 +142,7 @@ optional.add_argument('--verbose_sparse_matmul', action='store_true',
                       help='show computation times of sparse matrix multiplications.')
 
 optional.add_argument('--print_mem_usage', action='store_true',
-                help="print memory usage. Requires psutil module.")
+                help="print memory usage.")
 
 optional.add_argument('--print_interval', default=100, type=int,
                 help="Controls how often memory usage is printed.")
@@ -192,12 +193,6 @@ only_from_finish = inargs['only_from_finish']
 
 
 print_mem_usage = inargs['print_mem_usage']
-if print_mem_usage:
-    try:
-        import psutil
-    except ImportError:
-        print("Could not load psutil, will not print mem usage.")
-        print_mem_usage = False
 
 print_interval = inargs['print_interval']
 #%%

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
-pytest==8.3.2
-ruff==0.5.7
+pytest>=8.3.2
+ruff>=0.5.7


### PR DESCRIPTION
Properly define the minimal python version (i.e. the development version), as well as, the minimal set of python packages to install.

- We develop on python 3.9
- Minimal set of packages is separated into:
  - Packages required for the usage which is specified in `requirements.txt`
  - Packages required for development (testing, linting, etc) specified in `tests/requirements.txt`
  